### PR TITLE
Fix macosx_glimp to compile on 10.10

### DIFF
--- a/neo/sys/osx/macosx_glimp.mm
+++ b/neo/sys/osx/macosx_glimp.mm
@@ -63,7 +63,7 @@ static bool isHidden = false;
 @implementation NSOpenGLContext (CGLContextAccess)
 - (CGLContextObj) cglContext;
 {
-	return _contextAuxiliary;
+	return [self CGLContextObj];
 }
 @end
 


### PR DESCRIPTION
Change category on NSOpenGLContext to not depend on internal var for access to CGLContextObj.    CGLContextObj has been available [since 10.0](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/CGL_OpenGL/index.html#//apple_ref/c/tdef/CGLContextObj). 
