### PR TITLE
Add back support for full screen on OS X 

### DIFF
--- a/neo/sys/osx/macosx_glimp.mm
+++ b/neo/sys/osx/macosx_glimp.mm
@@ -676,7 +676,7 @@ void GLimp_SetGamma(unsigned short red[256],
 /*****************************************************************************/
 
 #pragma mark -
-#pragma mark ´ ATI_fragment_shader
+#pragma mark ¥ ATI_fragment_shader
 
 static GLuint sGeneratingProgram = 0;
 static int sCurrentPass;


### PR DESCRIPTION
The way full screen was handled no longer works so this updates `CreateGameWindow` to add back support.  

On OS X, [Apple asks that developers](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_fullscreen/opengl_cgl.html) not change the display resolution and instead simply create a window that takes up the entire screen, then [modify the back buffer](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_contexts/opengl_contexts.html#//apple_ref/doc/uid/TP40001987-CH216-SW28) to accommodate the specific drawing size you need if it does not match the display resolution.  

According to Apple, they notice when you create a window that takes up the entire screen and optimize your drawing context accordingly.
